### PR TITLE
Introduce TransactionManager class (an interface for end users)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,11 +1,8 @@
 ETH_RPC=https://rpc2.sepolia.org
 NEAR_MULTICHAIN_CONTRACT=v2.multichain-mpc.testnet
 
-NEAR_ACCOUNT_PRIVATE_KEY=
-# Note that these items produce your deterministic Safe Address
 NEAR_ACCOUNT_ID=
-RECOVERY_ADDRESS=
-SAFE_SALT_NONCE=0
+NEAR_ACCOUNT_PRIVATE_KEY=
 
 # Head to https://www.pimlico.io/ for an API key
 ERC4337_BUNDLER_URL=

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -16,13 +16,13 @@ export class Erc4337Bundler {
     usePaymaster: boolean,
     safeNotDeployed: boolean,
   ): Promise<PaymasterData> {
+    // TODO: Keep this option out of the bundler
     if (usePaymaster) {
       console.log("Requesting paymaster data...");
       const data = this.provider.send("pm_sponsorUserOperation", [
         { ...rawUserOp, signature: PLACEHOLDER_SIG },
         this.entryPointAddress,
       ]);
-      console.log("Paymaster Data", data);
       return data;
     }
     return defaultPaymasterData(safeNotDeployed);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,5 @@ export async function loadArgs(): Promise<UserOptions> {
       default: "0",
     })
     .help()
-    .alias("help", "h")
-    .argv;
+    .alias("help", "h").argv;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,13 @@ export async function loadArgs(): Promise<UserOptions> {
       description:
         "Recovery address to be attached as owner of the Safe (immediately adter deployment)",
       default: undefined,
-    }).argv;
+    })
+    .option("safeSaltNonce", {
+      type: "string",
+      description: "Salt nonce used for the Safe deployment",
+      default: "0",
+    })
+    .help()
+    .alias("help", "h")
+    .argv;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,17 @@
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+export async function loadArgs(): Promise<UserOptions> {
+  return yargs(hideBin(process.argv))
+    .option("usePaymaster", {
+      type: "boolean",
+      description: "Have transaction sponsored by paymaster service",
+      default: false,
+    })
+    .option("recoveryAddress", {
+      type: "string",
+      description:
+        "Recovery address to be attached as owner of the Safe (immediately adter deployment)",
+      default: undefined,
+    }).argv;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { UserOptions } from "./types";
 
 export async function loadArgs(): Promise<UserOptions> {
   return yargs(hideBin(process.argv))

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ dotenv.config();
 
 async function main() {
   const options = await loadArgs();
-  const txManager = await TransactionManager.fromEnv();
+  const txManager = await TransactionManager.fromEnv(options);
   const { unsignedUserOp, safeOpHash } = await txManager.buildTransaction({
     // TODO: Replace dummy transaction.
     transaction: { to: txManager.nearEOA, value: 1n, data: "0x69" },
@@ -14,13 +14,13 @@ async function main() {
   });
   console.log("Unsigned UserOp", unsignedUserOp);
   console.log("Safe Op Hash", safeOpHash);
-  
+
   // Ensure the Safe is funded if it's not using paymaster.
   await txManager.assertFunded(options.usePaymaster);
-  
+
   console.log("Signing with Near...");
   const signature = await txManager.signTransaction(safeOpHash);
-  
+
   console.log("Executing UserOp...");
   const userOpReceipt = await txManager.executeTransaction({
     ...unsignedUserOp,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,82 +1,28 @@
 import dotenv from "dotenv";
-import { ethers } from "ethers";
-import { NearEthAdapter, MultichainContract } from "near-ca";
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import { ContractSuite } from "./safe";
-import { getNearSignature } from "./near";
-import { Erc4337Bundler } from "./bundler";
-import { assertFunded, packSignature } from "./util";
+import { TransactionManager } from "./tx-manager";
+import { loadArgs } from "./cli";
 
 dotenv.config();
-const { SAFE_SALT_NONCE, ERC4337_BUNDLER_URL, ETH_RPC, RECOVERY_ADDRESS } =
-  process.env;
 
 async function main() {
-  const argv = await yargs(hideBin(process.argv)).option("usePaymaster", {
-    type: "boolean",
-    description: "Have transaction sponsored by paymaster service",
-    default: false,
-  }).argv;
-  const provider = new ethers.JsonRpcProvider(ETH_RPC);
-  const nearAdapter = await NearEthAdapter.fromConfig({
-    mpcContract: await MultichainContract.fromEnv(),
+  const options = await loadArgs();
+  const txManager = await TransactionManager.fromEnv();
+  const { unsignedUserOp, safeOpHash } = await txManager.buildTransaction({
+    // TODO: Replace dummy transaction.
+    transaction: { to: txManager.nearEOA, value: 1n, data: "0x69" },
+    options,
   });
-  console.log(
-    `NearEth Adapter: ${nearAdapter.nearAccountId()} <> ${nearAdapter.address}`,
-  );
-
-  const safePack = await ContractSuite.init(provider);
-  const bundler = new Erc4337Bundler(
-    ERC4337_BUNDLER_URL!,
-    await safePack.entryPoint.getAddress(),
-  );
-
-  // TODO(bh2smith): add the recovery as first tx (more deterministic)
-  const owners = [
-    nearAdapter.address,
-    ...(RECOVERY_ADDRESS ? [RECOVERY_ADDRESS] : []),
-  ];
-  const setup = await safePack.getSetup(owners);
-  const safeAddress = await safePack.addressForSetup(setup, SAFE_SALT_NONCE);
-  console.log("Safe Address:", safeAddress);
-  const safeNotDeployed = await assertFunded(
-    provider,
-    safeAddress,
-    argv.usePaymaster,
-  );
-
-  // TODO(bh2smith) Bundler Gas Feed: `pimlico_getUserOperationGasPrice`
-  const gasFees = await provider.getFeeData();
-
-  const rawUserOp = await safePack.buildUserOp(
-    { to: nearAdapter.address, value: 1n, data: "0x69" }, // Transaction Data:
-    safeAddress,
-    gasFees,
-    setup,
-    safeNotDeployed,
-    SAFE_SALT_NONCE || "0",
-  );
-  const paymasterData = await bundler.getPaymasterData(
-    rawUserOp,
-    argv.usePaymaster,
-    safeNotDeployed,
-  );
-
-  const unsignedUserOp = { ...rawUserOp, ...paymasterData };
   console.log("Unsigned UserOp", unsignedUserOp);
-  const safeOpHash = await safePack.getOpHash(unsignedUserOp, paymasterData);
-
+  console.log("Safe Op Hash", safeOpHash);
+  // Check that the Safe is funded if it's not using paymaster
+  await txManager.assertFunded(options.usePaymaster);
   console.log("Signing with Near...");
-  const signature = await getNearSignature(nearAdapter, safeOpHash);
-
-  const userOpHash = await bundler.sendUserOperation({
+  const signature = await txManager.signTransaction(safeOpHash);
+  console.log("Executing UserOp...");
+  const userOpReceipt = await txManager.executeTransaction({
     ...unsignedUserOp,
-    signature: packSignature(signature),
+    signature,
   });
-  console.log("UserOp Hash", userOpHash);
-
-  const userOpReceipt = await bundler.getUserOpReceipt(userOpHash);
   console.log("userOp Receipt", userOpReceipt);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,13 @@ async function main() {
   });
   console.log("Unsigned UserOp", unsignedUserOp);
   console.log("Safe Op Hash", safeOpHash);
-  // Check that the Safe is funded if it's not using paymaster
+  
+  // Ensure the Safe is funded if it's not using paymaster.
   await txManager.assertFunded(options.usePaymaster);
+  
   console.log("Signing with Near...");
   const signature = await txManager.signTransaction(safeOpHash);
+  
   console.log("Executing UserOp...");
   const userOpReceipt = await txManager.executeTransaction({
     ...unsignedUserOp,

--- a/src/safe.ts
+++ b/src/safe.ts
@@ -70,7 +70,7 @@ export class ContractSuite {
   async addressForSetup(
     setup: ethers.BytesLike,
     saltNonce?: string,
-  ): Promise<ethers.AddressLike> {
+  ): Promise<string> {
     // bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer), saltNonce));
     // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L58
     const salt = ethers.keccak256(
@@ -154,6 +154,7 @@ export class ContractSuite {
   }
 
   async buildUserOp(
+    // TODO: support Multisend
     txData: {
       to: `0x${string}`;
       value?: bigint;

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -1,0 +1,157 @@
+import { ethers } from "ethers";
+import { NearEthAdapter, MultichainContract } from "near-ca";
+import { ContractSuite } from "./safe";
+import { Erc4337Bundler } from "./bundler";
+import { packSignature } from "./util";
+import { getNearSignature } from "./near";
+import { UserOperation, UserOptions } from "./types";
+
+export class TransactionManager {
+  readonly provider: ethers.JsonRpcProvider;
+  readonly nearAdapter: NearEthAdapter;
+  private safePack: ContractSuite;
+  private bundler: Erc4337Bundler;
+  private setup: string;
+  readonly safeAddress: string;
+  private safeSaltNonce: string;
+  private _safeNotDeployed: boolean;
+
+  constructor(
+    provider: ethers.JsonRpcProvider,
+    nearAdapter: NearEthAdapter,
+    safePack: ContractSuite,
+    bundler: Erc4337Bundler,
+    setup: string,
+    safeAddress: string,
+    safeSaltNonce: string,
+    safeNotDeployed: boolean,
+  ) {
+    this.provider = provider;
+    this.nearAdapter = nearAdapter;
+    this.safePack = safePack;
+    this.bundler = bundler;
+    this.setup = setup;
+    this.safeAddress = safeAddress;
+    this.safeSaltNonce = safeSaltNonce;
+    this._safeNotDeployed = safeNotDeployed;
+  }
+
+  static async create(config: {
+    ethRpc: string;
+    erc4337BundlerUrl: string;
+    safeSaltNonce?: string;
+  }): Promise<TransactionManager> {
+    const provider = new ethers.JsonRpcProvider(config.ethRpc);
+    const [nearAdapter, safePack] = await Promise.all([
+      NearEthAdapter.fromConfig({
+        mpcContract: await MultichainContract.fromEnv(),
+      }),
+      ContractSuite.init(provider),
+    ]);
+    console.log(
+      `Near Adapter: ${nearAdapter.nearAccountId()} <> ${nearAdapter.address}`,
+    );
+    const bundler = new Erc4337Bundler(
+      config.erc4337BundlerUrl,
+      await safePack.entryPoint.getAddress(),
+    );
+    const setup = await safePack.getSetup([nearAdapter.address]);
+    const safeAddress = await safePack.addressForSetup(
+      setup,
+      config.safeSaltNonce,
+    );
+    const safeNotDeployed = (await provider.getCode(safeAddress)) === "0x";
+    console.log(`Safe Address: ${safeAddress} - deployed? ${!safeNotDeployed}`);
+    return new TransactionManager(
+      provider,
+      nearAdapter,
+      safePack,
+      bundler,
+      setup,
+      safeAddress,
+      config.safeSaltNonce || "0",
+      safeNotDeployed,
+    );
+  }
+
+  static async fromEnv(): Promise<TransactionManager> {
+    return TransactionManager.create({
+      ethRpc: process.env.ETH_RPC!,
+      erc4337BundlerUrl: process.env.ERC4337_BUNDLER_URL!,
+      safeSaltNonce: process.env.SAFE_SALT_NONCE,
+    });
+  }
+
+  get safeNotDeployed(): boolean {
+    return this._safeNotDeployed;
+  }
+
+  get nearEOA(): `0x${string}` {
+    return this.nearAdapter.address;
+  }
+
+  async getSafeBalance(): Promise<bigint> {
+    return await this.provider.getBalance(this.safeAddress);
+  }
+
+  async buildTransaction(args: {
+    transaction: { to: `0x${string}`; value: bigint; data: `0x${string}` };
+    options: UserOptions;
+  }): Promise<{ safeOpHash: string; unsignedUserOp: UserOperation }> {
+    const gasFees = await this.provider.getFeeData();
+    const { to, value, data } = args.transaction;
+    const rawUserOp = await this.safePack.buildUserOp(
+      { to, value, data },
+      this.safeAddress,
+      gasFees,
+      this.setup,
+      this.safeNotDeployed,
+      this.safeSaltNonce,
+    );
+
+    const paymasterData = await this.bundler.getPaymasterData(
+      rawUserOp,
+      args.options.usePaymaster,
+      this.safeNotDeployed,
+    );
+
+    const unsignedUserOp = { ...rawUserOp, ...paymasterData };
+    const safeOpHash = await this.safePack.getOpHash(
+      unsignedUserOp,
+      paymasterData,
+    );
+
+    return {
+      safeOpHash,
+      unsignedUserOp,
+    };
+  }
+
+  async signTransaction(safeOpHash: string): Promise<string> {
+    const signature = await getNearSignature(this.nearAdapter, safeOpHash);
+    return packSignature(signature);
+  }
+
+  async executeTransaction(userOp: UserOperation) {
+    const userOpHash = await this.bundler.sendUserOperation(userOp);
+    console.log("UserOp Hash", userOpHash);
+
+    const userOpReceipt = await this.bundler.getUserOpReceipt(userOpHash);
+    console.log("userOp Receipt", userOpReceipt);
+
+    // Update safeNotDeployed after the first transaction
+    this._safeNotDeployed =
+      (await this.provider.getCode(this.safeAddress)) === "0x";
+    return userOpReceipt;
+  }
+
+  async assertFunded(usePaymaster: boolean): Promise<void> {
+    if (this.safeNotDeployed && !usePaymaster) {
+      const safeBalance = await this.getSafeBalance();
+      if (safeBalance === 0n) {
+        console.log("WARN: Undeployed Safe is must be funded.");
+        process.exit(0);
+      }
+    }
+  }
+}

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -40,6 +40,7 @@ export class TransactionManager {
     ethRpc: string;
     erc4337BundlerUrl: string;
     safeSaltNonce?: string;
+    recoveryAddress?: string;
   }): Promise<TransactionManager> {
     const provider = new ethers.JsonRpcProvider(config.ethRpc);
     const [nearAdapter, safePack] = await Promise.all([
@@ -55,7 +56,12 @@ export class TransactionManager {
       config.erc4337BundlerUrl,
       await safePack.entryPoint.getAddress(),
     );
-    const setup = await safePack.getSetup([nearAdapter.address]);
+    // TODO(bh2smith): add the recovery as part of the first tx (more deterministic)
+    const owners = [
+      nearAdapter.address,
+      ...(config.recoveryAddress ? [config.recoveryAddress] : []),
+    ];
+    const setup = await safePack.getSetup(owners);
     const safeAddress = await safePack.addressForSetup(
       setup,
       config.safeSaltNonce,

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -74,11 +74,11 @@ export class TransactionManager {
     );
   }
 
-  static async fromEnv(): Promise<TransactionManager> {
+  static async fromEnv(options: UserOptions): Promise<TransactionManager> {
     return TransactionManager.create({
       ethRpc: process.env.ETH_RPC!,
       erc4337BundlerUrl: process.env.ERC4337_BUNDLER_URL!,
-      safeSaltNonce: process.env.SAFE_SALT_NONCE,
+      safeSaltNonce: options.safeSaltNonce,
     });
   }
 
@@ -149,7 +149,9 @@ export class TransactionManager {
     if (this.safeNotDeployed && !usePaymaster) {
       const safeBalance = await this.getSafeBalance();
       if (safeBalance === 0n) {
-        console.log("WARN: Undeployed Safe is must be funded.");
+        console.log(
+          `WARN: Undeployed Safe (${this.safeAddress}) must be funded when not using paymaster`,
+        );
         process.exit(0);
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,4 +30,5 @@ export interface PaymasterData {
 export interface UserOptions {
   usePaymaster: boolean;
   recoveryAddress: string | undefined;
+  safeSaltNonce: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,8 @@ export interface PaymasterData {
   callGasLimit: string;
   preVerificationGas: string;
 }
+
+export interface UserOptions {
+  usePaymaster: boolean;
+  recoveryAddress: string | undefined;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,23 +9,6 @@ export const PLACEHOLDER_SIG = ethers.solidityPacked(
 export const packGas = (hi: ethers.BigNumberish, lo: ethers.BigNumberish) =>
   ethers.solidityPacked(["uint128", "uint128"], [hi, lo]);
 
-export async function assertFunded(
-  provider: ethers.JsonRpcProvider,
-  safeAddress: ethers.AddressLike,
-  usePaymaster: boolean,
-): Promise<boolean> {
-  const safeNotDeployed = (await provider.getCode(safeAddress)) === "0x";
-  if (safeNotDeployed && !usePaymaster) {
-    // Check safe has been funded:
-    const safeBalance = await provider.getBalance(safeAddress);
-    if (safeBalance === 0n) {
-      console.log("WARN: Undeployed Safe is must be funded.");
-      process.exitCode = 1;
-    }
-  }
-  return safeNotDeployed;
-}
-
 export function packSignature(
   signature: string,
   validFrom: number = 0,


### PR DESCRIPTION
This PR simplifies main method of index.ts by essentially reducing it to an example. This is achieved by offloading complex logic and argument parsing to `tx-manager.ts` and `cli.ts`.

`recoveryAddress` & `safeSaltNonce` are now read from argv instead of env.

Quite a few simplifications to the code we made and some (user facing) function arguments were improved.
A few TODOs were also inserted in places where it made sense.