### PR TITLE
Add Recovery as Multisend (after deployment).

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,22 +10,23 @@ async function main() {
   const txManager = await TransactionManager.create({
     ethRpc: process.env.ETH_RPC!,
     erc4337BundlerUrl: process.env.ERC4337_BUNDLER_URL!,
-    options,
+    safeSaltNonce: options.safeSaltNonce,
   });
+  const transactions = [
+    // TODO: Replace dummy transaction with real user transaction.
+    {
+      to: "0xbeef4dad00000000000000000000000000000000",
+      value: "1", // 1 wei
+      data: "0xbeef",
+    },
+  ];
+  // Add Recovery if safe not deployed & recoveryAddress was provided.
+  if (txManager.safeNotDeployed && options.recoveryAddress) {
+    const recoveryTx = txManager.addOwnerTx(options.recoveryAddress);
+    transactions.push(recoveryTx);
+  }
   const { unsignedUserOp, safeOpHash } = await txManager.buildTransaction({
-    // TODO: Replace dummy transaction.
-    transactions: [
-      {
-        to: "0x0000000000000000000000000000000000000000",
-        value: "1",
-        data: "0x",
-      },
-      {
-        to: "0x0000000000000000000000000000000000000000",
-        value: "2",
-        data: "0x",
-      },
-    ],
+    transactions,
     options,
   });
   console.log("Unsigned UserOp", unsignedUserOp);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import { TransactionManager } from "./tx-manager";
 import { loadArgs } from "./cli";
+import { containsValue } from "./util";
 import { ethers } from "ethers";
 
 dotenv.config();
@@ -16,15 +17,17 @@ async function main() {
     // TODO: Replace dummy transaction with real user transaction.
     {
       to: "0xbeef4dad00000000000000000000000000000000",
-      value: "1", // 1 wei
+      value: "0", // 0 value transfer with non-trivial data.
       data: "0xbeef",
     },
   ];
   // Add Recovery if safe not deployed & recoveryAddress was provided.
   if (txManager.safeNotDeployed && options.recoveryAddress) {
     const recoveryTx = txManager.addOwnerTx(options.recoveryAddress);
+    // This would happen (sequentially) after the userTx, but all executed in a single
     transactions.push(recoveryTx);
   }
+
   const { unsignedUserOp, safeOpHash } = await txManager.buildTransaction({
     transactions,
     options,
@@ -32,9 +35,18 @@ async function main() {
   console.log("Unsigned UserOp", unsignedUserOp);
   console.log("Safe Op Hash", safeOpHash);
 
-  if (!options.usePaymaster) {
-    // Ensure the Safe is funded if it's not using paymaster.
-    await txManager.assertFunded();
+  // TODO: Evaluate gas cost (in ETH)
+  const gasCost = ethers.parseEther("0.01");
+  // Whenever not using paymaster, or on value transfer, the Safe must be funded.
+  const sufficientFunded = await txManager.safeSufficientlyFunded(
+    transactions,
+    options.usePaymaster ? 0n : gasCost,
+  );
+  if (!sufficientFunded) {
+    console.warn(
+      `Safe ${txManager.safeAddress} insufficiently funded to perform this transaction. Exiting...`,
+    );
+    process.exit(0); // soft exit with warning!
   }
 
   console.log("Signing with Near...");

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -152,15 +152,18 @@ export class TransactionManager {
     };
   }
 
-  async assertFunded(): Promise<void> {
-    if (this.safeNotDeployed) {
-      const safeBalance = await this.getSafeBalance();
-      if (safeBalance === 0n) {
-        console.log(
-          `WARN: Undeployed Safe (${this.safeAddress}) must be funded`,
-        );
-        process.exit(0);
-      }
+  async safeSufficientlyFunded(
+    transactions: MetaTransaction[],
+    gasCost: bigint,
+  ): Promise<boolean> {
+    const txValue = transactions.reduce(
+      (acc, tx) => acc + BigInt(tx.value),
+      0n,
+    );
+    if (txValue + gasCost === 0n) {
+      return true;
     }
+    const safeBalance = await this.getSafeBalance();
+    return txValue + gasCost < safeBalance;
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { PaymasterData } from "./types";
+import { MetaTransaction } from "ethers-multisend";
 
 export const PLACEHOLDER_SIG = ethers.solidityPacked(
   ["uint48", "uint48"],
@@ -31,4 +32,8 @@ export function packPaymasterData(data: PaymasterData) {
         ]),
       )
     : "0x";
+}
+
+export function containsValue(transactions: MetaTransaction[]): boolean {
+  return transactions.some((tx) => tx.value !== "0");
 }


### PR DESCRIPTION
Adding recovery address as part of a multisend transaction (i.e. not included in deployment) whenever safe is not yet deployed and recovery address is provided. This ensures that the safeAddress linked to the near account is more deterministic. With this the Safe Address will be uniquely determined by `nearAdapter.evmAddress` and `safeSaltNonce`. Note that `nearAdapter.evmAddress` is also determined by a parameter similar to `safeSaltNonce` (but from Near to EVM). This additional parameter is called the `derivationPath` (usually defaulting to "ethereum,1").

Note that we also improve the balance check here (to ensure the safe is sufficiently funded in all scenarios). 

Closes #18

### Test Plan

Still using the index script to verify (CI coming soon). Here is the first successful transaction adding owner (and sending a non-trivial - zero valued transaction via paymaster).

[0x2a9b70e7a1b957db66d4c113f3df850e119f61fc1d2cfc66b5ae54a3dbd94a0e](https://sepolia.etherscan.io/tx/0x2a9b70e7a1b957db66d4c113f3df850e119f61fc1d2cfc66b5ae54a3dbd94a0e)

I would be curious to determine how to extract the message that was sent to `0xbeef4dad00000000000000000000000000000000` which was meant to occur in this transaction. Is Etherscan not good at displaying this data? It appears to be [here](https://sepolia.etherscan.io/tx/0x2a9b70e7a1b957db66d4c113f3df850e119f61fc1d2cfc66b5ae54a3dbd94a0e/advanced#eventlog#117) but not so clearly displayed in the explorer (cc @nlordell)