### PR TITLE
Use Bundler Gas Feed

### DIFF
--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import {
+  GasPrices,
   PaymasterData,
   UnsignedUserOperation,
   UserOperation,
@@ -44,6 +45,10 @@ export class Erc4337Bundler {
       const error = (err as ethers.JsonRpcError).error;
       throw new Error(`Failed to send user op with: ${error.message}`);
     }
+  }
+
+  async getGasPrice(): Promise<GasPrices> {
+    return this.provider.send("pimlico_getUserOperationGasPrice", []);
   }
 
   async _getUserOpReceiptInner(

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -9,6 +9,7 @@ import {
 } from "@safe-global/safe-modules-deployments";
 import { PLACEHOLDER_SIG, packGas, packPaymasterData } from "../util.js";
 import {
+  GasPrice,
   PaymasterData,
   UnsignedUserOperation,
   UserOperation,
@@ -163,15 +164,11 @@ export class ContractSuite {
   async buildUserOp(
     txData: MetaTransaction,
     safeAddress: ethers.AddressLike,
-    feeData: ethers.FeeData,
+    feeData: GasPrice,
     setup: string,
     safeNotDeployed: boolean,
     safeSaltNonce: string
   ): Promise<UnsignedUserOperation> {
-    const { maxPriorityFeePerGas, maxFeePerGas } = feeData;
-    if (!maxPriorityFeePerGas || !maxFeePerGas) {
-      throw new Error("no gas fee data");
-    }
     const rawUserOp = {
       sender: safeAddress,
       nonce: ethers.toBeHex(await this.entryPoint.getNonce(safeAddress, 0)),
@@ -183,8 +180,7 @@ export class ContractSuite {
         txData.data,
         txData.operation || 0,
       ]),
-      maxPriorityFeePerGas: ethers.toBeHex((maxPriorityFeePerGas * 12n) / 10n),
-      maxFeePerGas: ethers.toBeHex(maxFeePerGas),
+      ...feeData,
     };
     return rawUserOp;
   }

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -92,7 +92,8 @@ export class TransactionManager {
     options: UserOptions;
   }): Promise<{ safeOpHash: string; unsignedUserOp: UserOperation }> {
     const { transactions, options } = args;
-    const gasFees = await this.provider.getFeeData();
+    const gasFees = (await this.bundler.getGasPrice()).fast;
+    // const gasFees = await this.provider.getFeeData();
     // Build Singular MetaTransaction for Multisend from transaction list.
     const tx =
       transactions.length > 1 ? encodeMulti(transactions) : transactions[0];

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,3 +80,14 @@ export type UserOperationReceipt = {
   receipt: Receipt;
   logs: Log[];
 };
+
+export interface GasPrices {
+  slow: GasPrice;
+  standard: GasPrice;
+  fast: GasPrice;
+}
+
+export interface GasPrice {
+  maxFeePerGas: Hex;
+  maxPriorityFeePerGas: Hex;
+}


### PR DESCRIPTION
This replaces `ethers.getFeeData` with bundler gas fee data. Note sure if we want to add the other fee data as a fallback... any thoughts?

Closes #3

Note that this makes us more reliant on a specific 3rd party service.