### PR TITLE
Cleanup & managerForChainId

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,4 +5,4 @@ NEAR_ACCOUNT_ID=
 NEAR_ACCOUNT_PRIVATE_KEY=
 
 # Head to https://www.pimlico.io/ for an API key
-ERC4337_BUNDLER_URL=
+PIMLICO_KEY=

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NEAR_ACCOUNT_ID=
 NEAR_ACCOUNT_PRIVATE_KEY=
 
 # Head to https://www.pimlico.io/ for an API key
-ERC4337_BUNDLER_URL=
+PIMLICO_KEY=
 ```
 
 

--- a/examples/load-manager.ts
+++ b/examples/load-manager.ts
@@ -1,0 +1,34 @@
+import dotenv from "dotenv";
+import { managerForChainId, TransactionManager } from "../src";
+import { MpcContract, nearAccountFromAccountId, NearEthAdapter } from "near-ca";
+
+dotenv.config();
+
+async function main(): Promise<void> {
+  const nearNetwork = {
+    networkId: "testnet",
+    nodeUrl: "https://rpc.testnet.near.org",
+  };
+  const nearAccount = await nearAccountFromAccountId(
+    process.env.NEAR_ACCOUNT_ID!,
+    nearNetwork
+  );
+  const nearAdapter = await NearEthAdapter.fromConfig({
+    mpcContract: new MpcContract(nearAccount, "v1.signer-prod.testnet"),
+  });
+  const managers = new Map<number, TransactionManager>();
+  console.log("Start");
+  for (const chainId of [100, 137, 11155111]) {
+    managers.set(
+      chainId,
+      await managerForChainId(nearAdapter, chainId, process.env.PIMLICO_KEY!)
+    );
+  }
+
+  console.log("Done");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   });
   const txManager = await TransactionManager.create({
     ethRpc: process.env.ETH_RPC!,
-    erc4337BundlerUrl: process.env.ERC4337_BUNDLER_URL!,
+    pimlicoKey: process.env.PIMLICO_KEY!,
     nearAdapter,
     safeSaltNonce: options.safeSaltNonce,
   });
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
   );
   if (!sufficientFunded) {
     console.warn(
-      `Safe ${txManager.safeAddress} insufficiently funded to perform this transaction. Exiting...`
+      `Safe ${txManager.address} insufficiently funded to perform this transaction. Exiting...`
     );
     process.exit(0); // soft exit with warning!
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,9 +878,9 @@
   integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
 
 "@types/node@^22.3.0":
-  version "22.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.4.tgz#83f7d1f65bc2ed223bdbf57c7884f1d5a4fa84e8"
-  integrity sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==
+  version "22.5.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
+  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
### **User description**
Note that this still needs UserOperation v0.6 support (all other chains apart from sepolia still use v0.6).


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added a new example script (`load-manager.ts`) to load transaction managers for multiple chain IDs.
- Updated `send-tx.ts` example script to use `PIMLICO_KEY` instead of `ERC4337_BUNDLER_URL`.
- Enhanced `ContractSuite` to handle fallback versions for contract deployment.
- Introduced `managerForChainId` function in `TransactionManager` for multi-chain support.
- Renamed `safeAddress` to `address` in `TransactionManager` for consistency.
- Updated `.env.sample` and `README.md` to reflect the change from `ERC4337_BUNDLER_URL` to `PIMLICO_KEY`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>load-manager.ts</strong><dd><code>Add example script for loading transaction managers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/load-manager.ts

<li>Added a new example script to load transaction managers for multiple <br>chain IDs.<br> <li> Utilizes the <code>managerForChainId</code> function to create transaction <br>managers.<br> <li> Configures NEAR account and adapter.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-bf70168086070d740cc844edc71de22fc6764c6a09d9ec1136d4b909dbcdc15b">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>send-tx.ts</strong><dd><code>Update example script to use Pimlico API key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/send-tx.ts

<li>Replaced <code>erc4337BundlerUrl</code> with <code>pimlicoKey</code> in the transaction manager <br>creation.<br> <li> Updated log message to use <code>address</code> instead of <code>safeAddress</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-caea28cbdc6aaa3ae4627ce08027a012a1ac50f994576edba425ab34500e9279">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safe.ts</strong><dd><code>Add fallback mechanism for contract deployment version</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/safe.ts

<li>Added error handling for deployment function to fall back to an older <br>version if the specified version is not found.<br> <li> Improved error message for deployment not found.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-61c404ab5cbdd55f0399112cd9443e907389128e886847bafb06179e8ac2df69">+10/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tx-manager.ts</strong><dd><code>Enhance TransactionManager with multi-chain support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tx-manager.ts

<li>Introduced <code>managerForChainId</code> function to create a transaction manager <br>based on chain ID.<br> <li> Replaced <code>erc4337BundlerUrl</code> with <code>pimlicoKey</code> in the transaction manager <br>creation.<br> <li> Renamed <code>safeAddress</code> to <code>address</code> for consistency.<br> <li> Added <code>chainId</code> method to <code>TransactionManager</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-af1933cfd9addf32b45f5151004905edaeed2f27bdb0820abff81c0be8cd79ca">+32/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.sample</strong><dd><code>Update environment variable sample for Pimlico API key</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.sample

- Replaced `ERC4337_BUNDLER_URL` with `PIMLICO_KEY`.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README for Pimlico API key usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Replaced <code>ERC4337_BUNDLER_URL</code> with <code>PIMLICO_KEY</code> in the environment <br>variable setup instructions.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/39/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

