### PR TITLE
Hacky Deployment Fetching

### DIFF
--- a/examples/load-manager.ts
+++ b/examples/load-manager.ts
@@ -12,7 +12,7 @@ async function main(): Promise<void> {
 
   const managers = new Map<number, TransactionManager>();
 
-  for (const chainId of [100, 137, 11155111]) {
+  for (const chainId of [1, 10, 100, 137, 11155111]) {
     managers.set(
       chainId,
       await TransactionManager.fromChainId({

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -205,13 +205,22 @@ async function getDeployment(
 ): Promise<ethers.Contract> {
   const { chainId } = await provider.getNetwork();
   const deployment = fn({ version });
-  if (!deployment || !deployment.networkAddresses[`${chainId}`]) {
+  if (!deployment) {
     throw new Error(
       `Deployment not found for ${fn.name} version ${version} on chainId ${chainId}`
     );
   }
+  let address = deployment.networkAddresses[`${chainId}`];
+  if (!address) {
+    // console.warn(
+    //   `Deployment asset ${fn.name} not listed on chainId ${chainId}, using likely fallback. For more info visit https://github.com/safe-global/safe-modules-deployments`
+    // );
+    // TODO: This is a cheeky hack. Real solution proposed in
+    // https://github.com/Mintbase/near-safe/issues/42
+    address = deployment.networkAddresses["11155111"];
+  }
   return new ethers.Contract(
-    deployment.networkAddresses[`${chainId}`],
+    address,
     deployment.abi as ethers.Fragment[],
     provider
   );


### PR DESCRIPTION
### **User description**
The Safe Deployment network lists we outdated, causing us to fallback on v0.2.0 contracts (totally undesired - due to loss of identical & deterministic addresses on all chains). We proposed an update here https://github.com/safe-global/safe-modules-deployments/pull/37

This PR just falls back on Sepolia for the deployment data (when not found in the list). This shouldn't cause problems in cases when the assets are deployed, but the user will run into issues on networks where the assets don't yet exist.

The proper solution here is proposed in #42 (the answer to life existence and everything).

In the meantime, this solution worked quite well and resulted in [this transaction](https://gnosisscan.io/tx/0x35bee01b1836ae6b214ec48910fc7a96a0b79e18f393cdb505b21ab271357a13) on Gnosis Chain!


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added support for more chain IDs in the `TransactionManager` in `examples/load-manager.ts`.
- Enhanced deployment fetching logic in `src/lib/safe.ts` to include a fallback address for missing deployments.
- Improved error handling and added comments for future improvements in deployment fetching.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>load-manager.ts</strong><dd><code>Add support for more chain IDs in TransactionManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/load-manager.ts

<li>Added support for additional chain IDs in the <code>TransactionManager</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/43/files#diff-bf70168086070d740cc844edc71de22fc6764c6a09d9ec1136d4b909dbcdc15b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safe.ts</strong><dd><code>Enhance deployment fetching with fallback mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/safe.ts

<li>Modified deployment fetching logic to include a fallback address.<br> <li> Added error handling for missing deployments.<br> <li> Included comments and TODOs for future improvements.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/43/files#diff-61c404ab5cbdd55f0399112cd9443e907389128e886847bafb06179e8ac2df69">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

