### PR TITLE
Deployed: viem migration bug

### DIFF
--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -1,6 +1,5 @@
 import dotenv from "dotenv";
 import { ethers } from "ethers";
-import { setupAdapter } from "near-ca";
 
 import { loadArgs, loadEnv } from "./cli";
 import { TransactionManager } from "../src";
@@ -19,7 +18,8 @@ async function main(): Promise<void> {
     pimlicoKey,
     privateKey: nearAccountPrivateKey,
   });
-
+  const deployed = await txManager.safeDeployed(chainId);
+  console.log("Deployed?", deployed)
   const transactions = [
     // TODO: Replace dummy transaction with real user transaction.
     {

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -13,7 +13,7 @@ import { Erc4337Bundler } from "./lib/bundler";
 import { encodeMulti } from "./lib/multisend";
 import { ContractSuite } from "./lib/safe";
 import { MetaTransaction, UserOperation, UserOperationReceipt } from "./types";
-import { packSignature } from "./util";
+import { isContract, packSignature } from "./util";
 
 export class TransactionManager {
   readonly nearAdapter: NearEthAdapter;
@@ -177,12 +177,11 @@ export class TransactionManager {
   }
 
   async safeDeployed(chainId: number): Promise<boolean> {
+    // Early exit if already known.
     if (chainId in this.deployedChains) {
       return true;
     }
-    const provider = Network.fromChainId(chainId).client;
-    const deployed =
-      (await provider.getCode({ address: this.address })) !== "0x";
+    const deployed = await isContract(this.address, chainId);
     if (deployed) {
       this.deployedChains.add(chainId);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
-import { Hex, concatHex, encodePacked, toHex } from "viem";
+import { Address, Hex, concatHex, encodePacked, toHex } from "viem";
 
 import { PaymasterData, MetaTransaction } from "./types";
+import { Network } from "near-ca";
 
 export const PLACEHOLDER_SIG = encodePacked(["uint48", "uint48"], [0, 0]);
 
@@ -24,15 +25,20 @@ export function packPaymasterData(data: PaymasterData): Hex {
   return (
     data.paymaster
       ? concatHex([
-          data.paymaster!,
-          toHex(BigInt(data.paymasterVerificationGasLimit || 0n), { size: 16 }),
-          toHex(BigInt(data.paymasterPostOpGasLimit || 0n), { size: 16 }),
-          data.paymasterData || "0x",
-        ])
+        data.paymaster!,
+        toHex(BigInt(data.paymasterVerificationGasLimit || 0n), { size: 16 }),
+        toHex(BigInt(data.paymasterPostOpGasLimit || 0n), { size: 16 }),
+        data.paymasterData || "0x",
+      ])
       : "0x"
   ) as Hex;
 }
 
 export function containsValue(transactions: MetaTransaction[]): boolean {
   return transactions.some((tx) => tx.value !== "0");
+}
+
+export async function isContract(address: Address, chainId: number): Promise<boolean> {
+  const client = Network.fromChainId(chainId).client;
+  return !!(await client.getCode({ address }));
 }


### PR DESCRIPTION
Unlike ethers, whose getCode function returns `0x` for no code deployed, viem returns undefined. This caused a false positive when detecting if the safe was deployed.