### PR TITLE
Migrate SafePack to Viem

### DIFF
--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
 import { ethers } from "ethers";
+import { isAddress } from "viem";
 
 import { loadArgs, loadEnv } from "./cli";
 import { TransactionManager } from "../src";
@@ -29,7 +30,11 @@ async function main(): Promise<void> {
     },
   ];
   // Add Recovery if safe not deployed & recoveryAddress was provided.
-  if (!(await txManager.safeDeployed(chainId)) && recoveryAddress) {
+  if (
+    !(await txManager.safeDeployed(chainId)) &&
+    recoveryAddress &&
+    isAddress(recoveryAddress)
+  ) {
     const recoveryTx = txManager.addOwnerTx(recoveryAddress);
     // This would happen (sequentially) after the userTx, but all executed in a single
     transactions.push(recoveryTx);

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -25,7 +25,9 @@ export class Erc4337Bundler {
     this.entryPointAddress = entryPointAddress;
     this.apiKey = apiKey;
     this.chainId = chainId;
-    this.provider = new ethers.JsonRpcProvider(bundlerUrl(chainId, this.apiKey));
+    this.provider = new ethers.JsonRpcProvider(
+      bundlerUrl(chainId, this.apiKey)
+    );
   }
 
   async getPaymasterData(

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -6,8 +6,21 @@ import {
   getSafe4337ModuleDeployment,
   getSafeModuleSetupDeployment,
 } from "@safe-global/safe-modules-deployments";
-import { ethers } from "ethers";
-import { Address, Hash, Hex } from "viem";
+import { Network } from "near-ca";
+import {
+  Address,
+  encodeFunctionData,
+  encodePacked,
+  getCreate2Address,
+  Hash,
+  Hex,
+  keccak256,
+  ParseAbi,
+  parseAbi,
+  PublicClient,
+  toHex,
+  zeroAddress,
+} from "viem";
 
 import {
   GasPrice,
@@ -17,26 +30,31 @@ import {
 } from "../types";
 import { PLACEHOLDER_SIG, packGas, packPaymasterData } from "../util";
 
+interface DeploymentData {
+  abi: unknown[] | ParseAbi<readonly string[]>;
+  address: `0x${string}`;
+}
+
 /**
  * All contracts used in account creation & execution
  */
 export class ContractSuite {
-  provider: ethers.JsonRpcProvider;
-  singleton: ethers.Contract;
-  proxyFactory: ethers.Contract;
-  m4337: ethers.Contract;
-  moduleSetup: ethers.Contract;
-  entryPoint: ethers.Contract;
+  client: PublicClient;
+  singleton: DeploymentData;
+  proxyFactory: DeploymentData;
+  m4337: DeploymentData;
+  moduleSetup: DeploymentData;
+  entryPoint: DeploymentData;
 
   constructor(
-    provider: ethers.JsonRpcProvider,
-    singleton: ethers.Contract,
-    proxyFactory: ethers.Contract,
-    m4337: ethers.Contract,
-    moduleSetup: ethers.Contract,
-    entryPoint: ethers.Contract
+    client: PublicClient,
+    singleton: DeploymentData,
+    proxyFactory: DeploymentData,
+    m4337: DeploymentData,
+    moduleSetup: DeploymentData,
+    entryPoint: DeploymentData
   ) {
-    this.provider = provider;
+    this.client = client;
     this.singleton = singleton;
     this.proxyFactory = proxyFactory;
     this.m4337 = m4337;
@@ -46,89 +64,106 @@ export class ContractSuite {
 
   static async init(): Promise<ContractSuite> {
     // TODO - this is a cheeky hack.
-    const provider = new ethers.JsonRpcProvider("https://rpc2.sepolia.org");
-    const safeDeployment = (fn: DeploymentFunction): Promise<ethers.Contract> =>
-      getDeployment(fn, { provider, version: "1.4.1" });
+    const client = Network.fromChainId(11155111).client;
+    const safeDeployment = (fn: DeploymentFunction): Promise<DeploymentData> =>
+      getDeployment(fn, { version: "1.4.1" });
     const m4337Deployment = async (
       fn: DeploymentFunction
-    ): Promise<ethers.Contract> => {
-      return getDeployment(fn, { provider, version: "0.3.0" });
+    ): Promise<DeploymentData> => {
+      return getDeployment(fn, { version: "0.3.0" });
     };
-    // Need this first to get entryPoint address
-    const m4337 = await m4337Deployment(getSafe4337ModuleDeployment);
 
-    const [singleton, proxyFactory, moduleSetup, supportedEntryPoint] =
-      await Promise.all([
-        safeDeployment(getSafeL2SingletonDeployment),
-        safeDeployment(getProxyFactoryDeployment),
-        m4337Deployment(getSafeModuleSetupDeployment),
-        m4337.SUPPORTED_ENTRYPOINT(),
-      ]);
-    const entryPoint = new ethers.Contract(
-      supportedEntryPoint,
-      ["function getNonce(address, uint192 key) view returns (uint256 nonce)"],
-      provider
-    );
-    console.log("Initialized ERC4337 & Safe Module Contracts:", {
-      singleton: await singleton.getAddress(),
-      proxyFactory: await proxyFactory.getAddress(),
-      m4337: await m4337.getAddress(),
-      moduleSetup: await moduleSetup.getAddress(),
-      entryPoint: await entryPoint.getAddress(),
-    });
+    const [singleton, proxyFactory, moduleSetup, m4337] = await Promise.all([
+      safeDeployment(getSafeL2SingletonDeployment),
+      safeDeployment(getProxyFactoryDeployment),
+      m4337Deployment(getSafeModuleSetupDeployment),
+      m4337Deployment(getSafe4337ModuleDeployment),
+    ]);
+
+    // console.log("Initialized ERC4337 & Safe Module Contracts:", {
+    //   singleton: await singleton.getAddress(),
+    //   proxyFactory: await proxyFactory.getAddress(),
+    //   m4337: await m4337.getAddress(),
+    //   moduleSetup: await moduleSetup.getAddress(),
+    //   entryPoint: await entryPoint.getAddress(),
+    // });
     return new ContractSuite(
-      provider,
+      client,
       singleton,
       proxyFactory,
       m4337,
       moduleSetup,
-      entryPoint
+      // EntryPoint:
+      {
+        address: (await client.readContract({
+          address: m4337.address,
+          abi: m4337.abi,
+          functionName: "SUPPORTED_ENTRYPOINT",
+        })) as Address,
+        abi: parseAbi([
+          "function getNonce(address, uint192 key) view returns (uint256 nonce)",
+        ]),
+      }
     );
   }
 
-  async addressForSetup(
-    setup: ethers.BytesLike,
-    saltNonce?: string
-  ): Promise<Address> {
+  async addressForSetup(setup: Hex, saltNonce?: string): Promise<Address> {
     // bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer), saltNonce));
     // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L58
-    const salt = ethers.keccak256(
-      ethers.solidityPacked(
+    const salt = keccak256(encodePacked(
         ["bytes32", "uint256"],
-        [ethers.keccak256(setup), saltNonce || 0]
+        [keccak256(setup), BigInt(saltNonce || "0")]
       )
     );
 
     // abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(_singleton)));
     // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L29
-    const initCode = ethers.solidityPacked(
+    const initCode = encodePacked(
       ["bytes", "uint256"],
       [
-        await this.proxyFactory.proxyCreationCode(),
-        await this.singleton.getAddress(),
+        (await this.client.readContract({
+          address: this.proxyFactory.address,
+          abi: this.proxyFactory.abi,
+          functionName: "proxyCreationCode",
+        })) as Hex,
+        BigInt(this.singleton.address),
       ]
     );
-    return ethers.getCreate2Address(
-      await this.proxyFactory.getAddress(),
+    return getCreate2Address({
+      from: this.proxyFactory.address,
       salt,
-      ethers.keccak256(initCode)
-    ) as Address;
+      bytecodeHash: keccak256(initCode),
+    });
   }
 
-  async getSetup(owners: string[]): Promise<Hex> {
-    const setup = await this.singleton.interface.encodeFunctionData("setup", [
-      owners,
-      1, // We use sign threshold of 1.
-      this.moduleSetup.target,
-      this.moduleSetup.interface.encodeFunctionData("enableModules", [
-        [this.m4337.target],
-      ]),
-      this.m4337.target,
-      ethers.ZeroAddress,
-      0,
-      ethers.ZeroAddress,
-    ]);
-    return setup as Hex;
+  
+  getSetup(owners: string[]): Hex {
+    return encodeFunctionData({
+      abi: this.singleton.abi,
+      functionName: "setup",
+      args: [
+        owners,
+        1, // We use sign threshold of 1.
+        this.moduleSetup.address,
+        encodeFunctionData({
+          abi: this.moduleSetup.abi,
+          functionName: "enableModules",
+          args: [[this.m4337.address]],
+        }),
+        this.m4337.address,
+        zeroAddress,
+        0,
+        zeroAddress,
+      ],
+    });
+  }
+
+  addOwnerData(newOwner: Address): Hex {
+    return encodeFunctionData({
+      abi: this.singleton.abi,
+      functionName: "addOwnerWithThreshold",
+      args: [newOwner, 1],
+    });
   }
 
   async getOpHash(unsignedUserOp: UserOperation): Promise<Hash> {
@@ -140,30 +175,39 @@ export class ContractSuite {
       maxPriorityFeePerGas,
       maxFeePerGas,
     } = unsignedUserOp;
-    return this.m4337.getOperationHash({
-      ...unsignedUserOp,
-      initCode: factory
-        ? ethers.solidityPacked(["address", "bytes"], [factory, factoryData])
-        : "0x",
-      accountGasLimits: packGas(verificationGasLimit, callGasLimit),
-      gasFees: packGas(maxPriorityFeePerGas, maxFeePerGas),
-      paymasterAndData: packPaymasterData(unsignedUserOp),
-      signature: PLACEHOLDER_SIG,
+    const opHash = await this.client.readContract({
+      address: this.m4337.address,
+      abi: this.m4337.abi,
+      functionName: "getOperationHash",
+      args: [
+        {
+          ...unsignedUserOp,
+          initCode: factory
+            ? encodePacked(["address", "bytes"], [factory, factoryData!])
+            : "0x",
+          accountGasLimits: packGas(verificationGasLimit, callGasLimit),
+          gasFees: packGas(maxPriorityFeePerGas, maxFeePerGas),
+          paymasterAndData: packPaymasterData(unsignedUserOp),
+          signature: PLACEHOLDER_SIG,
+        },
+      ],
     });
+    return opHash as Hash;
   }
 
-  factoryDataForSetup(
+  private factoryDataForSetup(
     safeNotDeployed: boolean,
     setup: string,
     safeSaltNonce: string
   ): { factory?: Address; factoryData?: Hex } {
     return safeNotDeployed
       ? {
-          factory: this.proxyFactory.target as Address,
-          factoryData: this.proxyFactory.interface.encodeFunctionData(
-            "createProxyWithNonce",
-            [this.singleton.target, setup, safeSaltNonce]
-          ) as Hex,
+          factory: this.proxyFactory.address,
+          factoryData: encodeFunctionData({
+            abi: this.proxyFactory.abi,
+            functionName: "createProxyWithNonce",
+            args: [this.singleton.address, setup, safeSaltNonce],
+          }),
         }
       : {};
   }
@@ -176,20 +220,29 @@ export class ContractSuite {
     safeNotDeployed: boolean,
     safeSaltNonce: string
   ): Promise<UnsignedUserOperation> {
-    const rawUserOp = {
+    const nonce = (await this.client.readContract({
+      abi: this.entryPoint.abi,
+      address: this.entryPoint.address,
+      functionName: "getNonce",
+      args: [safeAddress, 0],
+    })) as bigint;
+    return {
       sender: safeAddress,
-      nonce: ethers.toBeHex(await this.entryPoint.getNonce(safeAddress, 0)),
+      nonce: toHex(nonce),
       ...this.factoryDataForSetup(safeNotDeployed, setup, safeSaltNonce),
       // <https://github.com/safe-global/safe-modules/blob/9a18245f546bf2a8ed9bdc2b04aae44f949ec7a0/modules/4337/contracts/Safe4337Module.sol#L172>
-      callData: this.m4337.interface.encodeFunctionData("executeUserOp", [
-        txData.to,
-        BigInt(txData.value),
-        txData.data,
-        txData.operation || 0,
-      ]) as Hex,
+      callData: encodeFunctionData({
+        abi: this.m4337.abi,
+        functionName: "executeUserOp",
+        args: [
+          txData.to,
+          BigInt(txData.value),
+          txData.data,
+          txData.operation || 0,
+        ],
+      }),
       ...feeData,
     };
-    return rawUserOp;
   }
 }
 
@@ -198,31 +251,19 @@ type DeploymentFunction = (filter?: {
 }) =>
   | { networkAddresses: { [chainId: string]: string }; abi: unknown[] }
   | undefined;
-type DeploymentArgs = { provider: ethers.JsonRpcProvider; version: string };
+type DeploymentArgs = { version: string };
 
 async function getDeployment(
   fn: DeploymentFunction,
-  { provider, version }: DeploymentArgs
-): Promise<ethers.Contract> {
-  const { chainId } = await provider.getNetwork();
+  { version }: DeploymentArgs
+): Promise<DeploymentData> {
   const deployment = fn({ version });
   if (!deployment) {
-    throw new Error(
-      `Deployment not found for ${fn.name} version ${version} on chainId ${chainId}`
-    );
+    throw new Error(`Deployment not found for ${fn.name} version ${version}`);
   }
-  let address = deployment.networkAddresses[`${chainId}`];
-  if (!address) {
-    // console.warn(
-    //   `Deployment asset ${fn.name} not listed on chainId ${chainId}, using likely fallback. For more info visit https://github.com/safe-global/safe-modules-deployments`
-    // );
-    // TODO: This is a cheeky hack. Real solution proposed in
-    // https://github.com/Mintbase/near-safe/issues/42
-    address = deployment.networkAddresses["11155111"];
-  }
-  return new ethers.Contract(
-    address,
-    deployment.abi as ethers.Fragment[],
-    provider
-  );
+  // TODO: maybe call parseAbi on deployment.abi here.
+  return {
+    address: deployment.networkAddresses["11155111"] as Address,
+    abi: deployment.abi,
+  };
 }

--- a/src/tx-manager.ts
+++ b/src/tx-manager.ts
@@ -3,7 +3,6 @@ import {
   NearEthAdapter,
   NearEthTxData,
   BaseTx,
-  Network,
   setupAdapter,
   signatureFromOutcome,
 } from "near-ca";

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,5 +43,5 @@ export async function isContract(
   chainId: number
 ): Promise<boolean> {
   const client = Network.fromChainId(chainId).client;
-  return !!(await client.getCode({ address }));
+  return (await client.getCode({ address })) !== undefined;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,12 @@
 import { Network } from "near-ca";
-import { Address, Hex, concatHex, encodePacked, toHex } from "viem";
+import {
+  Address,
+  Hex,
+  concatHex,
+  encodePacked,
+  toHex,
+  PublicClient,
+} from "viem";
 
 import { PaymasterData, MetaTransaction } from "./types";
 
@@ -42,6 +49,9 @@ export async function isContract(
   address: Address,
   chainId: number
 ): Promise<boolean> {
-  const client = Network.fromChainId(chainId).client;
-  return (await client.getCode({ address })) !== undefined;
+  return (await getClient(chainId).getCode({ address })) !== undefined;
+}
+
+export function getClient(chainId: number): PublicClient {
+  return Network.fromChainId(chainId).client;
 }

--- a/tests/ethers-safe.ts
+++ b/tests/ethers-safe.ts
@@ -1,0 +1,234 @@
+import {
+  getProxyFactoryDeployment,
+  getSafeL2SingletonDeployment,
+} from "@safe-global/safe-deployments";
+import {
+  getSafe4337ModuleDeployment,
+  getSafeModuleSetupDeployment,
+} from "@safe-global/safe-modules-deployments";
+import { ethers } from "ethers";
+import { Address, Hash, Hex } from "viem";
+
+import {
+  GasPrice,
+  MetaTransaction,
+  UnsignedUserOperation,
+  UserOperation,
+} from "../src/types";
+import { PLACEHOLDER_SIG, packGas, packPaymasterData } from "../src/util";
+
+/**
+ * All contracts used in account creation & execution
+ */
+export class ContractSuite {
+  provider: ethers.JsonRpcProvider;
+  singleton: ethers.Contract;
+  proxyFactory: ethers.Contract;
+  m4337: ethers.Contract;
+  moduleSetup: ethers.Contract;
+  entryPoint: ethers.Contract;
+
+  constructor(
+    provider: ethers.JsonRpcProvider,
+    singleton: ethers.Contract,
+    proxyFactory: ethers.Contract,
+    m4337: ethers.Contract,
+    moduleSetup: ethers.Contract,
+    entryPoint: ethers.Contract
+  ) {
+    this.provider = provider;
+    this.singleton = singleton;
+    this.proxyFactory = proxyFactory;
+    this.m4337 = m4337;
+    this.moduleSetup = moduleSetup;
+    this.entryPoint = entryPoint;
+  }
+
+  static async init(): Promise<ContractSuite> {
+    // TODO - this is a cheeky hack.
+    const provider = new ethers.JsonRpcProvider("https://rpc2.sepolia.org");
+    const safeDeployment = (fn: DeploymentFunction): Promise<ethers.Contract> =>
+      getDeployment(fn, { provider, version: "1.4.1" });
+    const m4337Deployment = async (
+      fn: DeploymentFunction
+    ): Promise<ethers.Contract> => {
+      return getDeployment(fn, { provider, version: "0.3.0" });
+    };
+    // Need this first to get entryPoint address
+    const m4337 = await m4337Deployment(getSafe4337ModuleDeployment);
+
+    const [singleton, proxyFactory, moduleSetup, supportedEntryPoint] =
+      await Promise.all([
+        safeDeployment(getSafeL2SingletonDeployment),
+        safeDeployment(getProxyFactoryDeployment),
+        m4337Deployment(getSafeModuleSetupDeployment),
+        m4337.SUPPORTED_ENTRYPOINT(),
+      ]);
+    const entryPoint = new ethers.Contract(
+      supportedEntryPoint,
+      ["function getNonce(address, uint192 key) view returns (uint256 nonce)"],
+      provider
+    );
+    console.log("Initialized ERC4337 & Safe Module Contracts:", {
+      singleton: await singleton.getAddress(),
+      proxyFactory: await proxyFactory.getAddress(),
+      m4337: await m4337.getAddress(),
+      moduleSetup: await moduleSetup.getAddress(),
+      entryPoint: await entryPoint.getAddress(),
+    });
+    return new ContractSuite(
+      provider,
+      singleton,
+      proxyFactory,
+      m4337,
+      moduleSetup,
+      entryPoint
+    );
+  }
+
+  async addressForSetup(
+    setup: ethers.BytesLike,
+    saltNonce?: string
+  ): Promise<Address> {
+    // bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer), saltNonce));
+    // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L58
+    const salt = ethers.keccak256(
+      ethers.solidityPacked(
+        ["bytes32", "uint256"],
+        [ethers.keccak256(setup), saltNonce || 0]
+      )
+    );
+
+    // abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(_singleton)));
+    // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L29
+    const initCode = ethers.solidityPacked(
+      ["bytes", "uint256"],
+      [
+        await this.proxyFactory.proxyCreationCode(),
+        await this.singleton.getAddress(),
+      ]
+    );
+    return ethers.getCreate2Address(
+      await this.proxyFactory.getAddress(),
+      salt,
+      ethers.keccak256(initCode)
+    ) as Address;
+  }
+
+  getSetup(owners: string[]): Hex {
+    return this.singleton.interface.encodeFunctionData("setup", [
+      owners,
+      1, // We use sign threshold of 1.
+      this.moduleSetup.target,
+      this.moduleSetup.interface.encodeFunctionData("enableModules", [
+        [this.m4337.target],
+      ]),
+      this.m4337.target,
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+    ]) as Hex;
+  }
+
+  addOwnerData(newOwner: Address): Hex {
+    return this.singleton.interface.encodeFunctionData(
+      "addOwnerWithThreshold",
+      [newOwner, 1]
+    ) as Hex;
+  }
+
+  async getOpHash(unsignedUserOp: UserOperation): Promise<Hash> {
+    const {
+      factory,
+      factoryData,
+      verificationGasLimit,
+      callGasLimit,
+      maxPriorityFeePerGas,
+      maxFeePerGas,
+    } = unsignedUserOp;
+    return this.m4337.getOperationHash({
+      ...unsignedUserOp,
+      initCode: factory
+        ? ethers.solidityPacked(["address", "bytes"], [factory, factoryData])
+        : "0x",
+      accountGasLimits: packGas(verificationGasLimit, callGasLimit),
+      gasFees: packGas(maxPriorityFeePerGas, maxFeePerGas),
+      paymasterAndData: packPaymasterData(unsignedUserOp),
+      signature: PLACEHOLDER_SIG,
+    });
+  }
+
+  factoryDataForSetup(
+    safeNotDeployed: boolean,
+    setup: string,
+    safeSaltNonce: string
+  ): { factory?: Address; factoryData?: Hex } {
+    return safeNotDeployed
+      ? {
+          factory: this.proxyFactory.target as Address,
+          factoryData: this.proxyFactory.interface.encodeFunctionData(
+            "createProxyWithNonce",
+            [this.singleton.target, setup, safeSaltNonce]
+          ) as Hex,
+        }
+      : {};
+  }
+
+  async buildUserOp(
+    txData: MetaTransaction,
+    safeAddress: Address,
+    feeData: GasPrice,
+    setup: string,
+    safeNotDeployed: boolean,
+    safeSaltNonce: string
+  ): Promise<UnsignedUserOperation> {
+    const rawUserOp = {
+      sender: safeAddress,
+      nonce: ethers.toBeHex(await this.entryPoint.getNonce(safeAddress, 0)),
+      ...this.factoryDataForSetup(safeNotDeployed, setup, safeSaltNonce),
+      // <https://github.com/safe-global/safe-modules/blob/9a18245f546bf2a8ed9bdc2b04aae44f949ec7a0/modules/4337/contracts/Safe4337Module.sol#L172>
+      callData: this.m4337.interface.encodeFunctionData("executeUserOp", [
+        txData.to,
+        BigInt(txData.value),
+        txData.data,
+        txData.operation || 0,
+      ]) as Hex,
+      ...feeData,
+    };
+    return rawUserOp;
+  }
+}
+
+type DeploymentFunction = (filter?: {
+  version: string;
+}) =>
+  | { networkAddresses: { [chainId: string]: string }; abi: unknown[] }
+  | undefined;
+type DeploymentArgs = { provider: ethers.JsonRpcProvider; version: string };
+
+async function getDeployment(
+  fn: DeploymentFunction,
+  { provider, version }: DeploymentArgs
+): Promise<ethers.Contract> {
+  const { chainId } = await provider.getNetwork();
+  const deployment = fn({ version });
+  if (!deployment) {
+    throw new Error(
+      `Deployment not found for ${fn.name} version ${version} on chainId ${chainId}`
+    );
+  }
+  let address = deployment.networkAddresses[`${chainId}`];
+  if (!address) {
+    // console.warn(
+    //   `Deployment asset ${fn.name} not listed on chainId ${chainId}, using likely fallback. For more info visit https://github.com/safe-global/safe-modules-deployments`
+    // );
+    // TODO: This is a cheeky hack. Real solution proposed in
+    // https://github.com/Mintbase/near-safe/issues/42
+    address = deployment.networkAddresses["11155111"];
+  }
+  return new ethers.Contract(
+    address,
+    deployment.abi as ethers.Fragment[],
+    provider
+  );
+}

--- a/tests/lib.safe.spec.ts
+++ b/tests/lib.safe.spec.ts
@@ -1,30 +1,68 @@
+import { zeroAddress } from "viem";
+
 import { ContractSuite as EthPack } from "./ethers-safe";
 import { ContractSuite as ViemPack } from "../src/lib/safe";
 
 describe("Safe Pack", () => {
+  let ethersPack: EthPack;
+  let viemPack: ViemPack;
+  beforeAll(async () => {
+    ethersPack = await EthPack.init();
+    viemPack = await ViemPack.init();
+  });
 
   it("init", async () => {
-    const ethersPack = await EthPack.init();
-    const viemPack = await ViemPack.init();
-
-
     expect(ethersPack.singleton.target).toEqual(viemPack.singleton.address);
-    expect(await ethersPack.singleton.getAddress()).toEqual(viemPack.singleton.address);
-
+    expect(await ethersPack.singleton.getAddress()).toEqual(
+      viemPack.singleton.address
+    );
 
     expect(ethersPack.m4337.target).toEqual(viemPack.m4337.address);
     expect(await ethersPack.m4337.getAddress()).toEqual(viemPack.m4337.address);
 
     expect(ethersPack.moduleSetup.target).toEqual(viemPack.moduleSetup.address);
-    expect(await ethersPack.moduleSetup.getAddress()).toEqual(viemPack.moduleSetup.address);
+    expect(await ethersPack.moduleSetup.getAddress()).toEqual(
+      viemPack.moduleSetup.address
+    );
 
     expect(ethersPack.moduleSetup.target).toEqual(viemPack.moduleSetup.address);
-    expect(await ethersPack.moduleSetup.getAddress()).toEqual(viemPack.moduleSetup.address);
+    expect(await ethersPack.moduleSetup.getAddress()).toEqual(
+      viemPack.moduleSetup.address
+    );
 
     expect(ethersPack.entryPoint.target).toEqual(viemPack.entryPoint.address);
-    expect(await ethersPack.entryPoint.getAddress()).toEqual(viemPack.entryPoint.address);
+    expect(await ethersPack.entryPoint.getAddress()).toEqual(
+      viemPack.entryPoint.address
+    );
 
-    expect(ethersPack.proxyFactory.target).toEqual(viemPack.proxyFactory.address);
-    expect(await ethersPack.proxyFactory.getAddress()).toEqual(viemPack.proxyFactory.address);
+    expect(ethersPack.proxyFactory.target).toEqual(
+      viemPack.proxyFactory.address
+    );
+    expect(await ethersPack.proxyFactory.getAddress()).toEqual(
+      viemPack.proxyFactory.address
+    );
+  });
+
+  it("addOwnerData", () => {
+    expect(ethersPack.addOwnerData(zeroAddress)).toEqual(
+      viemPack.addOwnerData(zeroAddress)
+    );
+  });
+  it("getSetup", () => {
+    expect(ethersPack.getSetup([zeroAddress])).toEqual(
+      viemPack.getSetup([zeroAddress])
+    );
+  });
+
+  it("getSetup", async () => {
+    const setup = viemPack.getSetup([zeroAddress]);
+    const [eps0, vps0, eps1, vps1] = await Promise.all([
+      ethersPack.addressForSetup(setup),
+      viemPack.addressForSetup(setup),
+      ethersPack.addressForSetup(setup, "1"),
+      viemPack.addressForSetup(setup, "1"),
+    ]);
+    expect(eps0).toEqual(vps0);
+    expect(eps1).toEqual(vps1);
   });
 });

--- a/tests/lib.safe.spec.ts
+++ b/tests/lib.safe.spec.ts
@@ -1,0 +1,30 @@
+import { ContractSuite as EthPack } from "./ethers-safe";
+import { ContractSuite as ViemPack } from "../src/lib/safe";
+
+describe("Safe Pack", () => {
+
+  it("init", async () => {
+    const ethersPack = await EthPack.init();
+    const viemPack = await ViemPack.init();
+
+
+    expect(ethersPack.singleton.target).toEqual(viemPack.singleton.address);
+    expect(await ethersPack.singleton.getAddress()).toEqual(viemPack.singleton.address);
+
+
+    expect(ethersPack.m4337.target).toEqual(viemPack.m4337.address);
+    expect(await ethersPack.m4337.getAddress()).toEqual(viemPack.m4337.address);
+
+    expect(ethersPack.moduleSetup.target).toEqual(viemPack.moduleSetup.address);
+    expect(await ethersPack.moduleSetup.getAddress()).toEqual(viemPack.moduleSetup.address);
+
+    expect(ethersPack.moduleSetup.target).toEqual(viemPack.moduleSetup.address);
+    expect(await ethersPack.moduleSetup.getAddress()).toEqual(viemPack.moduleSetup.address);
+
+    expect(ethersPack.entryPoint.target).toEqual(viemPack.entryPoint.address);
+    expect(await ethersPack.entryPoint.getAddress()).toEqual(viemPack.entryPoint.address);
+
+    expect(ethersPack.proxyFactory.target).toEqual(viemPack.proxyFactory.address);
+    expect(await ethersPack.proxyFactory.getAddress()).toEqual(viemPack.proxyFactory.address);
+  });
+});

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -68,11 +68,11 @@ describe("Utility Functions (mostly byte packing)", () => {
     expect(containsValue([VALUE_TX, NO_VALUE_TX])).toBe(true);
   });
 
-  it("isContract", () => {
+  it("isContract", async () => {
     const chainId = 11155111;
-    expect(isContract(zeroAddress, chainId)).toBe(false);
+    expect(await isContract(zeroAddress, chainId)).toBe(false);
     expect(
-      isContract("0x9008D19f58AAbD9eD0D60971565AA8510560ab41", chainId)
+      await isContract("0x9008D19f58AAbD9eD0D60971565AA8510560ab41", chainId)
     ).toBe(true);
   });
 });


### PR DESCRIPTION
### **User description**
We no longer require ethers in the `lib/utils` directory. This is a move toward a bit more type safety, consistency and detanglement from the network client and the contract instances.

Last step to remove ethers entirely will be to replace the ethers.JsonRpcProvider with PublicClient in lib/bundler. Then we can move ethers to a dev dependency and use it for unit testing our encodings.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Migrated contract interactions from `ethers` to `viem` in `src/lib/safe.ts`.
- Updated `TransactionManager` to use `viem` and improved transaction handling.
- Added `getClient` utility function and updated `isContract` function.
- Added tests to compare `ethers` and `viem` implementations.
- Reformatted code and improved readability in multiple files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>send-tx.ts</strong><dd><code>Add address validation using `viem` in transaction example</code></dd></summary>
<hr>

examples/send-tx.ts

- Added `isAddress` check from `viem` to validate `recoveryAddress`.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-caea28cbdc6aaa3ae4627ce08027a012a1ac50f994576edba425ab34500e9279">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safe.ts</strong><dd><code>Migrate contract interactions from `ethers` to `viem`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/safe.ts

<li>Replaced <code>ethers</code> with <code>viem</code> for contract interactions.<br> <li> Introduced <code>DeploymentData</code> interface.<br> <li> Added new methods for encoding and address calculations.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-61c404ab5cbdd55f0399112cd9443e907389128e886847bafb06179e8ac2df69">+169/-118</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tx-manager.ts</strong><dd><code>Update TransactionManager to use <code>viem</code> and improve transaction handling</code></dd></summary>
<hr>

src/tx-manager.ts

<li>Removed <code>entryPointAddress</code> from <code>TransactionManager</code>.<br> <li> Updated methods to use <code>viem</code> for contract interactions.<br> <li> Added nonce fetching and improved transaction building.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-af1933cfd9addf32b45f5151004905edaeed2f27bdb0820abff81c0be8cd79ca">+22/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.ts</strong><dd><code>Add `getClient` utility and update `isContract` function</code>&nbsp; </dd></summary>
<hr>

src/util.ts

<li>Added <code>getClient</code> function to retrieve <code>PublicClient</code>.<br> <li> Updated <code>isContract</code> to use <code>getClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1">+13/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bundler.ts</strong><dd><code>Reformat provider instantiation in bundler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/bundler.ts

- Reformatted `ethers.JsonRpcProvider` instantiation.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-976637092fe76814f27bd72eb4e584f89cd321743afb4255c9496a99a717b1df">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ethers-safe.ts</strong><dd><code>Add comparison tests for `ethers` and `viem` implementations</code></dd></summary>
<hr>

tests/ethers-safe.ts

- Added a test file to compare `ethers` and `viem` implementations.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-a0ad94cd2d9a3ae333d2101fcd3adc10975ea67a002c30ef4ad358cd27c4060d">+234/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.safe.spec.ts</strong><dd><code>Add tests for `ContractSuite` initialization and methods</code>&nbsp; </dd></summary>
<hr>

tests/lib.safe.spec.ts

- Added tests for `ContractSuite` initialization and methods.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-041160d9ade01bbcb4ce7245c5396fad03a0112bc1c6beb21c9904789eb49ea0">+68/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.spec.ts</strong><dd><code>Update `isContract` test to be asynchronous</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils.spec.ts

- Updated `isContract` test to be asynchronous.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/53/files#diff-8a11aed3fd14509fa8b7e3166218e52d1f162a60b88151211391f28260ff71f6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

