### PR TITLE
UserOperation Request Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@safe-global/safe-gateway-typescript-sdk": "^3.22.2",
     "@safe-global/safe-modules-deployments": "^2.2.0",
     "near-api-js": "^5.0.0",
-    "near-ca": "^0.5.2",
+    "near-ca": "^0.5.6",
     "semver": "^7.6.3",
     "viem": "^2.16.5"
   },

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,7 @@ import {
 
 import { PaymasterData, MetaTransaction } from "./types";
 
+//
 export const PLACEHOLDER_SIG = encodePacked(["uint48", "uint48"], [0, 0]);
 
 type IntLike = Hex | bigint | string | number;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { Network } from "near-ca";
+import { EthTransactionParams, Network, SessionRequestParams } from "near-ca";
 import {
   Address,
   Hex,
@@ -6,6 +6,9 @@ import {
   encodePacked,
   toHex,
   PublicClient,
+  isHex,
+  parseTransaction,
+  zeroAddress,
 } from "viem";
 
 import { PaymasterData, MetaTransaction } from "./types";
@@ -55,4 +58,29 @@ export async function isContract(
 
 export function getClient(chainId: number): PublicClient {
   return Network.fromChainId(chainId).client;
+}
+
+export function metaTransactionsFromRequest(
+  params: SessionRequestParams
+): MetaTransaction[] {
+  let transactions: EthTransactionParams[];
+  if (isHex(params)) {
+    // If RLP hex is given, decode the transaction and build EthTransactionParams
+    const tx = parseTransaction(params);
+    transactions = [
+      {
+        from: zeroAddress, // TODO: This is a hack - but its unused.
+        to: tx.to!,
+        value: tx.value ? toHex(tx.value) : "0x00",
+        data: tx.data || "0x",
+      },
+    ];
+  } else {
+    transactions = params as EthTransactionParams[];
+  }
+  return transactions.map((tx) => ({
+    to: tx.to,
+    value: tx.value || "0x00",
+    data: tx.data || "0x",
+  }));
 }

--- a/tests/lib/safe-message.spec.ts
+++ b/tests/lib/safe-message.spec.ts
@@ -1,6 +1,6 @@
 import { zeroAddress } from "viem";
 
-import { decodedSafeMessage } from "../../src/lib/safe-message";
+import { decodeSafeMessage } from "../../src/lib/safe-message";
 
 describe("Multisend", () => {
   const plainMessage = `Welcome to OpenSea!
@@ -22,7 +22,7 @@ Nonce:
     version: "1.4.1+L2",
   };
   it("decodeSafeMessage", () => {
-    expect(decodedSafeMessage(plainMessage, safeInfo)).toStrictEqual({
+    expect(decodeSafeMessage(plainMessage, safeInfo)).toStrictEqual({
       decodedMessage: plainMessage,
       safeMessageMessage:
         "0xc90ef7cffa3b5b1422e6c49ca7a5d7c1e9f514db067ec9bad52db13e83cbbb7c",
@@ -31,7 +31,7 @@ Nonce:
     });
     // Lower Safe Version.
     expect(
-      decodedSafeMessage(plainMessage, { ...safeInfo, version: "1.2.1" })
+      decodeSafeMessage(plainMessage, { ...safeInfo, version: "1.2.1" })
     ).toStrictEqual({
       decodedMessage: plainMessage,
       safeMessageMessage:
@@ -47,7 +47,7 @@ Nonce:
       chainId: "1",
       version: null,
     };
-    expect(() => decodedSafeMessage(plainMessage, versionlessSafeInfo)).toThrow(
+    expect(() => decodeSafeMessage(plainMessage, versionlessSafeInfo)).toThrow(
       "Cannot create SafeMessage without version information"
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,9 +1173,9 @@
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
 "@safe-global/safe-deployments@^1.37.0":
-  version "1.37.7"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.7.tgz#35ccbb7f4cb0bb19be71403344930ba1ffd76cfe"
-  integrity sha512-vbmkWJoJsZ3btMl7PBMUIO/LGsQj4kB29zAuTMOLgb7GmN6avhqPcHKOIjbEKXisxvkVeUYZJWqCiKbZxnvGVA==
+  version "1.37.8"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.8.tgz#5d51a57e4c3a9274ce09d8fe7fbe1265a1aaf4c4"
+  integrity sha512-BT34eqSJ1K+4xJgJVY3/Yxg8TRTEvFppkt4wcirIPGCgR4/j06HptHPyDdmmqTuvih8wi8OpFHi0ncP+cGlXWA==
   dependencies:
     semver "^7.6.2"
 
@@ -1190,9 +1190,9 @@
   integrity sha512-H0XpusyXVcsTuRsQSq0FoBKqRfhZH87/1DrFEmXXPXmI3fJkvxq3KpTaTTqzcqoIe/J+erwVZQUYNfL68EcvAQ==
 
 "@scure/base@~1.1.6", "@scure/base@~1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.8.tgz#8f23646c352f020c83bca750a82789e246d42b50"
-  integrity sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
 
 "@scure/bip32@1.4.0":
   version "1.4.0"
@@ -1575,10 +1575,10 @@
     events "^3.3.0"
     isomorphic-unfetch "^3.1.0"
 
-"@walletconnect/core@2.16.1", "@walletconnect/core@^2.10.1":
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.16.1.tgz#019b181387792e0d284e75074b961b48193d9b6a"
-  integrity sha512-UlsnEMT5wwFvmxEjX8s4oju7R3zadxNbZgsFeHEsjh7uknY2zgmUe1Lfc5XU6zyPb1Jx7Nqpdx1KN485ee8ogw==
+"@walletconnect/core@2.16.2", "@walletconnect/core@^2.10.1":
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.16.2.tgz#49c471d0e1cc4e0326165c8c7d7178aee56d7e6a"
+  integrity sha512-Xf1SqLSB8KffNsgUGDE/CguAcKMD+3EKfqfqNhWpimxe1QDZDUw8xq+nnxfx6MAb8fdx9GYe6Lvknx2SAAeAHw==
   dependencies:
     "@walletconnect/heartbeat" "1.2.2"
     "@walletconnect/jsonrpc-provider" "1.0.14"
@@ -1591,8 +1591,8 @@
     "@walletconnect/relay-auth" "1.0.4"
     "@walletconnect/safe-json" "1.0.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.16.1"
-    "@walletconnect/utils" "2.16.1"
+    "@walletconnect/types" "2.16.2"
+    "@walletconnect/utils" "2.16.2"
     events "3.3.0"
     lodash.isequal "4.5.0"
     uint8arrays "3.1.0"
@@ -1700,19 +1700,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@2.16.1":
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.16.1.tgz#94a2f630ba741bd180f540c53576c5ceaace4857"
-  integrity sha512-s2Tx2n2duxt+sHtuWXrN9yZVaHaYqcEcjwlTD+55/vs5NUPlISf+fFmZLwSeX1kUlrSBrAuxPUcqQuRTKcjLOA==
+"@walletconnect/sign-client@2.16.2":
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.16.2.tgz#2356c3418bce0b867a661a2bddafd6b8bb02214a"
+  integrity sha512-R/hk2P3UN5u3FV22E7h9S/Oy8IbDwaBGH7St/BzOpJCjFmf6CF5S3GZVjrXPBesvRF94CROkqMF89wz5HkZepA==
   dependencies:
-    "@walletconnect/core" "2.16.1"
+    "@walletconnect/core" "2.16.2"
     "@walletconnect/events" "1.0.1"
     "@walletconnect/heartbeat" "1.2.2"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "2.1.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.16.1"
-    "@walletconnect/utils" "2.16.1"
+    "@walletconnect/types" "2.16.2"
+    "@walletconnect/utils" "2.16.2"
     events "3.3.0"
 
 "@walletconnect/time@1.0.2", "@walletconnect/time@^1.0.2":
@@ -1722,10 +1722,10 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.16.1":
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.16.1.tgz#6583d458d3f7b1919d482ba516ccb7878ec8c91f"
-  integrity sha512-9P4RG4VoDEF+yBF/n2TF12gsvT/aTaeZTVDb/AOayafqiPnmrQZMKmNCJJjq1sfdsDcHXFcZWMGsuCeSJCmrXA==
+"@walletconnect/types@2.16.2":
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.16.2.tgz#a8bd9d09e6248f72c79686881e4aae46306e6ea0"
+  integrity sha512-IIV9kQh6b/WpwhfgPixpziE+8XK/FtdnfvN1oOMs5h+lgwr46OJknPY2p7eS6vvdvEP3xMEc1Kbu1i4tlnroiw==
   dependencies:
     "@walletconnect/events" "1.0.1"
     "@walletconnect/heartbeat" "1.2.2"
@@ -1734,10 +1734,10 @@
     "@walletconnect/logger" "2.1.2"
     events "3.3.0"
 
-"@walletconnect/utils@2.16.1", "@walletconnect/utils@^2.10.1":
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.16.1.tgz#2099cc2bd16b0edc32022f64aa2c2c323b45d1d4"
-  integrity sha512-aoQirVoDoiiEtYeYDtNtQxFzwO/oCrz9zqeEEXYJaAwXlGVTS34KFe7W3/Rxd/pldTYKFOZsku2EzpISfH8Wsw==
+"@walletconnect/utils@2.16.2", "@walletconnect/utils@^2.10.1":
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.16.2.tgz#e7afbec7bf7ad7a4e86b2c5de233df3865d8cd23"
+  integrity sha512-CEMxMCIqvwXd8YIEXfBoCiWY8DtUevJ/w14Si+cmTHWHBDWKRZll7+QUXgICIBx5kyX3GMAKNABaTlg2A2CPSg==
   dependencies:
     "@stablelib/chacha20poly1305" "1.0.1"
     "@stablelib/hkdf" "1.0.1"
@@ -1748,7 +1748,7 @@
     "@walletconnect/relay-auth" "1.0.4"
     "@walletconnect/safe-json" "1.0.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.16.1"
+    "@walletconnect/types" "2.16.2"
     "@walletconnect/window-getters" "1.0.1"
     "@walletconnect/window-metadata" "1.0.1"
     detect-browser "5.3.0"
@@ -1757,18 +1757,18 @@
     uint8arrays "3.1.0"
 
 "@walletconnect/web3wallet@^1.13.0":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/web3wallet/-/web3wallet-1.15.1.tgz#47d041c07e2b12824ade85e53ed50c89536ef37b"
-  integrity sha512-EgtdZUgtf0diU98x8Q8tiZslE0Z5comnxv3SqmAIgkdhpXDxaM/goo7BC1yC+Wey/IHOOVYg2SW+La2Txk+6hQ==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/web3wallet/-/web3wallet-1.15.2.tgz#61c60bf71f430bbd45a4393d0090862bbb6b4486"
+  integrity sha512-7U2G/GA6zgsTzqdQOV0MEcj7CSZdvP/URKITWF45hkhlxscQg0N+TqFWGcPkym8t4kI4mqa5QnY5K5I+HhWTPA==
   dependencies:
     "@walletconnect/auth-client" "2.1.2"
-    "@walletconnect/core" "2.16.1"
+    "@walletconnect/core" "2.16.2"
     "@walletconnect/jsonrpc-provider" "1.0.14"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "2.1.2"
-    "@walletconnect/sign-client" "2.16.1"
-    "@walletconnect/types" "2.16.1"
-    "@walletconnect/utils" "2.16.1"
+    "@walletconnect/sign-client" "2.16.2"
+    "@walletconnect/types" "2.16.2"
+    "@walletconnect/utils" "2.16.2"
 
 "@walletconnect/window-getters@1.0.1", "@walletconnect/window-getters@^1.0.1":
   version "1.0.1"
@@ -2134,9 +2134,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001660"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz#31218de3463fabb44d0b7607b652e56edf2e2355"
-  integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
+  version "1.0.30001662"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz#3574b22dfec54a3f3b6787331da1040fe8e763ec"
+  integrity sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -2445,9 +2445,9 @@ ejs@^3.1.10:
     jake "^10.8.5"
 
 electron-to-chromium@^1.5.4:
-  version "1.5.23"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.23.tgz#6dabd8f7fec5cbf618b732ff4c42950dcc7a3be5"
-  integrity sha512-mBhODedOXg4v5QWwl21DjM5amzjmI1zw9EPrPK/5Wx7C8jt33bpZNrC7OhHUG3pxRtbLpr3W2dXT+Ph1SsfRZA==
+  version "1.5.25"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz#492ade1cde401332b9b75aa0c55fd5e1550ca66c"
+  integrity sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==
 
 elliptic@6.5.4:
   version "6.5.4"
@@ -4283,10 +4283,10 @@ near-api-js@^5.0.0:
     near-abi "0.1.1"
     node-fetch "2.6.7"
 
-near-ca@^0.5.2:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.5.5.tgz#0aeedd7de082d2e1f58181c1a2a86785dc5644e4"
-  integrity sha512-ZeQ4gMepacsFGp2gPhxSkEtW+3LX2100KWWkMZ7zQvbTlHpurFyQA6zoVRSmskAwDfCxACDJ811GAtEL7U7Fhw==
+near-ca@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.5.6.tgz#a8d556c096501b7ef3d67ad129520683bf3f2eb2"
+  integrity sha512-h5fZrg6xOFkH4DB41VaNvKUKgjkERMZTSOFHxnMwkGS+P2UTRUjzqq/e1EMadrMetT1+yb8BKjRyfacxsS9b3Q==
   dependencies:
     "@walletconnect/web3wallet" "^1.13.0"
     elliptic "^6.5.6"
@@ -5346,9 +5346,9 @@ v8-to-istanbul@^9.0.1:
     convert-source-map "^2.0.0"
 
 viem@^2.16.5, viem@^2.21.6:
-  version "2.21.7"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.7.tgz#c933fd3adb6f771e5c5fe2b4d7a14d8701ddc32f"
-  integrity sha512-PFgppakInuHX31wHDx1dzAjhj4t6Po6WrWtutDi33z2vabIT0Wv8qT6tl7DLqfLy2NkTqfN2mdshYLeoI5ZHvQ==
+  version "2.21.9"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.9.tgz#5676f81b07286ad88852a239e1eeb18c7f9b40a6"
+  integrity sha512-fWPDX2ABEo/mLiDN+wsmYJDJk0a/ZCafquxInR2+HZv/7UTgHbLgjZs4SotpEeFAYjgVThJ7A9TPmrRjaaYqvw==
   dependencies:
     "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.4.0"


### PR DESCRIPTION
### **User description**
Recent version of near-ca added a better EIP712TypedData type for our request router.

We update the encodeSignRequest to call into a custom built request router that should support several important Safe signature requests. 


___

### **PR Type**
dependencies, enhancement


___

### **Description**
- Updated the `near-ca` dependency version from `^0.5.2` to `^0.5.6` in `package.json`.
- The new version of `near-ca` includes a better `EIP712TypedData` type for the request router.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update `near-ca` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Updated `near-ca` dependency version from `^0.5.2` to `^0.5.6`



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/57/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

