### PR TITLE
Fix Bug: UserOpHash for chainId

### DIFF
--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
     usePaymaster,
   });
   console.log("Unsigned UserOp", unsignedUserOp);
-  const safeOpHash = await txManager.opHash(unsignedUserOp);
+  const safeOpHash = await txManager.opHash(chainId, unsignedUserOp);
   console.log("Safe Op Hash", safeOpHash);
 
   // TODO: Evaluate gas cost (in ETH)

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -24,14 +24,10 @@ function bundlerUrl(chainId: number, apikey: string): string {
   return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${apikey}`;
 }
 
-type SponsorshipPolicy = {
-  sponsorshipPolicyId: string;
-};
-
 type BundlerRpcSchema = [
   {
     Method: "pm_sponsorUserOperation";
-    Parameters: [UnsignedUserOperation, Address, SponsorshipPolicy | undefined];
+    Parameters: [UnsignedUserOperation, Address];
     ReturnType: PaymasterData;
   },
   {
@@ -81,7 +77,6 @@ export class Erc4337Bundler {
           params: [
             { ...rawUserOp, signature: PLACEHOLDER_SIG },
             this.entryPointAddress,
-            undefined,
           ],
         })
       );

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -24,10 +24,14 @@ function bundlerUrl(chainId: number, apikey: string): string {
   return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${apikey}`;
 }
 
+type SponsorshipPolicy = {
+  sponsorshipPolicyId: string;
+};
+
 type BundlerRpcSchema = [
   {
     Method: "pm_sponsorUserOperation";
-    Parameters: [UnsignedUserOperation, Address];
+    Parameters: [UnsignedUserOperation, Address, SponsorshipPolicy | undefined];
     ReturnType: PaymasterData;
   },
   {
@@ -77,6 +81,7 @@ export class Erc4337Bundler {
           params: [
             { ...rawUserOp, signature: PLACEHOLDER_SIG },
             this.entryPointAddress,
+            undefined,
           ],
         })
       );

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -107,7 +107,10 @@ export class SafeContractSuite {
     });
   }
 
-  async getOpHash(unsignedUserOp: UserOperation): Promise<Hash> {
+  async getOpHash(
+    chainId: number,
+    unsignedUserOp: UserOperation
+  ): Promise<Hash> {
     const {
       factory,
       factoryData,
@@ -116,7 +119,8 @@ export class SafeContractSuite {
       maxPriorityFeePerGas,
       maxFeePerGas,
     } = unsignedUserOp;
-    const opHash = await this.dummyClient.readContract({
+    const client = await getClient(chainId);
+    const opHash = await client.readContract({
       address: this.m4337.address,
       abi: this.m4337.abi,
       functionName: "getOperationHash",

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -208,8 +208,8 @@ export class NearSafe {
    * @param {UserOperation} userOp - The user operation for which the hash needs to be computed.
    * @returns {Promise<Hash>} - A promise that resolves to the hash of the provided user operation.
    */
-  async opHash(userOp: UserOperation): Promise<Hash> {
-    return this.safePack.getOpHash(userOp);
+  async opHash(chainId: number, userOp: UserOperation): Promise<Hash> {
+    return this.safePack.getOpHash(chainId, userOp);
   }
 
   /**
@@ -455,11 +455,11 @@ export class NearSafe {
           transactions,
           usePaymaster,
         });
-        const opHash = await this.opHash(userOp);
+        const opHash = await this.opHash(chainId, userOp);
         return {
           payload: toPayload(opHash),
           evmMessage: JSON.stringify(userOp),
-          hash: await this.opHash(userOp),
+          hash: await this.opHash(chainId, userOp),
         };
       }
     }


### PR DESCRIPTION
### **User description**
The Op Hash is evaluated onchain as a contract read. The network ID is likely sprinkled into the hash function so that we can not use the dummy/Sepolia client to evaluate on other networks.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the `opHash` function to include `chainId` as a parameter across multiple files.
- Modified the `getOpHash` method in `SafeContractSuite` to accept and utilize `chainId`.
- Updated `NearSafe` class to ensure `chainId` is passed to `opHash` method calls.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>send-tx.ts</strong><dd><code>Add chainId parameter to opHash function call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/send-tx.ts

<li>Updated the <code>opHash</code> function call to include <code>chainId</code> as a parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/72/files#diff-caea28cbdc6aaa3ae4627ce08027a012a1ac50f994576edba425ab34500e9279">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safe.ts</strong><dd><code>Modify getOpHash to include chainId parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/safe.ts

<li>Modified <code>getOpHash</code> method to accept <code>chainId</code> as a parameter.<br> <li> Updated client retrieval to use <code>chainId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/72/files#diff-61c404ab5cbdd55f0399112cd9443e907389128e886847bafb06179e8ac2df69">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>near-safe.ts</strong><dd><code>Update opHash method to require chainId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/near-safe.ts

<li>Updated <code>opHash</code> method to include <code>chainId</code> parameter.<br> <li> Adjusted method calls to pass <code>chainId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-safe/pull/72/files#diff-eaa2b6365c0d1469be7cdeec51b653d9551825a7f819995e332164a86987c3c1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

